### PR TITLE
feat: add QueryResult and CommandResult types

### DIFF
--- a/example/src/app.controller.ts
+++ b/example/src/app.controller.ts
@@ -1,3 +1,4 @@
+import { CommandResult, QueryResult } from '@nestjs-architects/typed-cqrs';
 import { Controller, Get } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { SomeCommand, SomeQuery } from './feature';
@@ -7,10 +8,10 @@ export class AppController {
   constructor(private readonly queryBus: QueryBus, private readonly commandBus: CommandBus) {}
 
   @Get()
-  async getHello(): Promise<string> {
-    const result: string = await this.commandBus.execute(new SomeCommand());
-
+  async getHello(): Promise<QueryResult<SomeQuery>> {
+    const result: CommandResult<SomeCommand> = await this.commandBus.execute(new SomeCommand());
     console.log(result);
+
     return this.queryBus.execute(new SomeQuery());
   }
 }

--- a/example/src/feature/some-command-handler.ts
+++ b/example/src/feature/some-command-handler.ts
@@ -1,9 +1,10 @@
+import { CommandResult } from '@nestjs-architects/typed-cqrs';
 import { CommandHandler, IInferredCommandHandler } from '@nestjs/cqrs';
 import { SomeCommand } from './some-command';
 
 @CommandHandler(SomeCommand)
 export class SomeCommandHandler implements IInferredCommandHandler<SomeCommand> {
-  async execute(command: SomeCommand): Promise<string> {
+  async execute(command: SomeCommand): Promise<CommandResult<SomeCommand>> {
     return 'Command result';
   }
 }

--- a/example/src/feature/some-handler.ts
+++ b/example/src/feature/some-handler.ts
@@ -1,10 +1,11 @@
+import { QueryResult } from '@nestjs-architects/typed-cqrs';
 import { QueryHandler, IInferredQueryHandler } from '@nestjs/cqrs';
 import { SomeQuery } from './some-query';
 
 @QueryHandler(SomeQuery)
 export class SomeHandler implements IInferredQueryHandler<SomeQuery> {
   // try changing to :Promise<number> and return value of number -> error!
-  async execute(query: SomeQuery): Promise<string> {
+  async execute(query: SomeQuery): Promise<QueryResult<SomeQuery>> {
     return 'Hello';
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nestjs-architects/typed-cqrs",
-  "version": "1.0.0",
+  "version": "1.0.1-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nestjs-architects/typed-cqrs",
-      "version": "1.0.0",
+      "version": "1.0.1-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/common": "^9.0.0",

--- a/src/command.ts
+++ b/src/command.ts
@@ -3,3 +3,9 @@ import { ICommand } from '@nestjs/cqrs';
 export class Command<T> implements ICommand {
   resultType$e1ca39fa!: T;
 }
+
+export type CommandResult<CommandT extends Command<unknown>> = CommandT extends Command<
+  infer ResultT
+>
+  ? ResultT
+  : never;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { Query } from './query';
 import { ICommandHandler, IQueryHandler } from '@nestjs/cqrs';
 
-export { Command } from './command';
-export { Query } from './query';
+export { Command, CommandResult } from './command';
+export { Query, QueryResult } from './query';
 
 import * as cqrs from '@nestjs/cqrs';
 import { Command } from './command';

--- a/src/query.ts
+++ b/src/query.ts
@@ -3,3 +3,7 @@ import { IQuery } from '@nestjs/cqrs';
 export class Query<T> implements IQuery {
   resultType$f9fbca36!: T;
 }
+
+export type QueryResult<QueryT extends Query<unknown>> = QueryT extends Query<infer ResultT>
+  ? ResultT
+  : never;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/valueadd-poland/nestjs-packages/blob/master/CONTRIBUTING.md#git-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

You need to manually look up the query/command result type if you want to pass it on.

## What is the new behavior?

Added `QueryResult` and `CommandResult` types to extract the return type from the typed `Query` & `Command` classes.
Let me know if it's nice for you :)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
