### PR TITLE
feat(typed-cqrs): use symbol field to store type of query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,7 @@
   "version": "1.1.2-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
+  "dev": true,
   "packages": {
     "": {
       "name": "@nestjs-architects/typed-cqrs",
@@ -22,7 +23,7 @@
         "prettier": "2.2.1",
         "reflect-metadata": "0.1.13",
         "rxjs": "^7.2.0",
-        "typescript": "4.2.4"
+        "typescript": "^5.4.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2964,16 +2965,16 @@
       "peer": true
     },
     "node_modules/typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unpipe": {
@@ -5348,9 +5349,9 @@
       "peer": true
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier": "2.2.1",
     "reflect-metadata": "0.1.13",
     "rxjs": "^7.2.0",
-    "typescript": "4.2.4"
+    "typescript": "^5.4.5"
   },
   "husky": {
     "hooks": {

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,7 +1,8 @@
 import { ICommand } from '@nestjs/cqrs';
+import { resultType } from './symbols';
 
 export class Command<T> implements ICommand {
-  resultType$e1ca39fa!: T;
+  protected [resultType]!: T;
 }
 
 export type CommandResult<CommandT extends Command<unknown>> = CommandT extends Command<

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,7 +1,8 @@
 import { IQuery } from '@nestjs/cqrs';
+import { resultType } from './symbols';
 
 export class Query<T> implements IQuery {
-  resultType$f9fbca36!: T;
+  protected [resultType]!: T;
 }
 
 export type QueryResult<QueryT extends Query<unknown>> = QueryT extends Query<infer ResultT>

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,0 +1,1 @@
+export const resultType = Symbol('resultType')


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs-architect/typed-cqrs/blob/master/CONTRIBUTING.md#git-guidelines *(probably yes, but the link is broken)*
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

* Updates typescript (in order to use symbols), while adding dependency to itself so that the examples type check correctly after `npm run build` without needing to use link.
* The type of commands and queries is now stored in a symbol field, which makes it invisible in consumer code (unlike previous implementation based on a random name) 


```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The same as before, only now there's no random property visible on the query.

Issue Number: N/A

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] Maybe, if someone depended on the random property, which I doubt.
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Fixes #4 